### PR TITLE
Add parbreaks for single authors, affiliations, or abstracts

### DIFF
--- a/lapreprint.typ
+++ b/lapreprint.typ
@@ -198,7 +198,6 @@
   }
   // Authors and affiliations
   if authors.len() > 0 {
-    parbreak()
     box(inset: (y: 10pt), {
       authors.map(author => {
         text(11pt, weight: "semibold", author.name)
@@ -213,7 +212,6 @@
     })
   }
   if affiliations.len() > 0 {
-    parbreak()
     box(inset: (bottom: 10pt), {
       affiliations.map(affiliation => {
         super(affiliation.id)
@@ -284,10 +282,8 @@
       abs.content
     }).join(parbreak())
   })
-  if (abstracts.len() == 1) {
-    parbreak()
-  }
   if (keywords.len() > 0) {
+    parbreak()
     text(size: 9pt, {
       text(fill: theme, weight: "semibold", "Keywords")
       h(8pt)

--- a/lapreprint.typ
+++ b/lapreprint.typ
@@ -198,6 +198,7 @@
   }
   // Authors and affiliations
   if authors.len() > 0 {
+    parbreak()
     box(inset: (y: 10pt), {
       authors.map(author => {
         text(11pt, weight: "semibold", author.name)
@@ -212,6 +213,7 @@
     })
   }
   if affiliations.len() > 0 {
+    parbreak()
     box(inset: (bottom: 10pt), {
       affiliations.map(affiliation => {
         super(affiliation.id)
@@ -282,6 +284,9 @@
       abs.content
     }).join(parbreak())
   })
+  if (abstracts.len() == 1) {
+    parbreak()
+  }
   if (keywords.len() > 0) {
     text(size: 9pt, {
       text(fill: theme, weight: "semibold", "Keywords")


### PR DESCRIPTION
When authors, affiliations, or abstracts only contain a single element, paragraph breaks don't get applied.

It would seem `join` looks like a no-op when the list has a single element, which breaks on abstracts.

Authors/affiliations seem to wrap based on length, rather than a deliberate break.